### PR TITLE
Add "module" entry point for ESM consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "3.2.0",
   "license": "MIT",
   "main": "lib/index.js",
+  "module": "src/index.js",
   "files": [
     "lib"
   ],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "lib/index.js",
   "module": "src/index.js",
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "keywords": [
     "indexeddb",


### PR DESCRIPTION
This allows bundlers to tree-shake and only pull in the specific functions that people want to import.